### PR TITLE
change yq install

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -81,7 +81,6 @@ runs:
       shell: bash
       run: |-
         sudo apt install python3 python3-pip libyaml-dev
-        sudo snap install yq
 
     # install latest version of yq
     - name: Install yq


### PR DESCRIPTION
### Type of Change
<!-- What type of change does your code introduce? -->
- [ ] New feature
- [ * ] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

### Resolves
- Fixes yq permission problem caused by snap. install yq directly from github release instead to snap. this solves permission problem and inability install w snap --classic

### Describe Changes
<!-- Describe your changes in detail, if applicable. -->
_Describe what this Pull Request does_
