### PR TITLE
mask TUTOR_OPENEDX_MONGODB_PASSWORD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,23 @@
 # CHANGE LOG
 
+## Version 1.0.4 (2022-09-03)
+
+- mask TUTOR_OPENEDX_MONGODB_PASSWORD
+
 ## Version 1.0.3 (2022-07-13)
 
-Add an input `tutor-version` and default to "14.0.2"
+- Add an input `tutor-version` and default to "14.0.2"
 
 ## Version 1.0.2 (2022-06-23)
 
-ADD masks for sensitive data generated and echoed to the console by tutor during
-config, build and deploy operations
+- ADD masks for sensitive data generated and echoed to the console by tutor during config, build and deploy operations
 
 ## Version 1.0.0 (2022-06-16)
 
-General production release.
+- General production release.
 
 ## Version 0.0.1 (2022-06-01)
 
 **Experimental. Do not use in production.**
 
-* Initial Git import
+- Initial Git import

--- a/action.yml
+++ b/action.yml
@@ -149,6 +149,7 @@ runs:
         echo "JWT_RSA_PRIVATE_KEY=''" >> $GITHUB_ENV
         echo "COMMENTS_SERVICE_KEY=''" >> $GITHUB_ENV
         echo "EMAIL_HOST_PASSWORD=''" >> $GITHUB_ENV
+        echo "TUTOR_OPENEDX_MONGODB_PASSWORD=''" >> $GITHUB_ENV
 
     # Note: data stored as k8s secrets are masked as they
     #       are extracted by openedx-actions/tutor-k8s-get-secret
@@ -182,3 +183,4 @@ runs:
         echo "::add-mask::$JWT_RSA_PRIVATE_KEY"
         echo "::add-mask::$COMMENTS_SERVICE_KEY"
         echo "::add-mask::$EMAIL_HOST_PASSWORD"
+        echo "::add-mask::$TUTOR_OPENEDX_MONGODB_PASSWORD"


### PR DESCRIPTION
### Type of Change
<!-- What type of change does your code introduce? -->
- [ * ] New feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

### Describe Changes
this is part of the rollout of the new remote MongoDB feature of Cookiecutter openedx_devops. the value of TUTOR_OPENEDX_MONGODB_PASSWORD should be masked in console output.